### PR TITLE
Refactor distinguishable_colors API

### DIFF
--- a/src/Color.jl
+++ b/src/Color.jl
@@ -869,8 +869,8 @@ end
 function distinguishable_colors{T<:ColorValue}(n::Integer,
                             seed::Vector{T};
                             transform::Function = identity,
-                            lchoices::Vector{Float64} = linspace(0,100,15),
-                            cchoices::Vector{Float64} = linspace(-100,100,15),
+                            lchoices::Vector{Float64} = linspace(0, 100, 15),
+                            cchoices::Vector{Float64} = linspace(0, 100, 15),
                             hchoices::Vector{Float64} = linspace(0, 340, 20))
     if n <= length(seed)
         return seed[1:n]


### PR DESCRIPTION
I wanted to make this easier to call, and allow one to supply multiple seed colors.

CC @dcjones:
- I'm not at all confident I've provided the right defaults for l, c, and h. Your expertise is particularly desired here.
- If the user doesn't supply any seed colors, note the first color will be equivalent to LHCab(lchoices[1], cchoices[1], hchoices[1]). We should make sure that's a reasonable color.
- Is RGB the right default output type when one calls this simply with an integer argument, `distinguishable_colors(5)`? Or would a different type be better?
