### PR TITLE
added weighted_color_mean and linspace functions (linear color ramp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,16 @@ formula (see `colordiff`), after first applying a transformation function
 `colordiff(transform(a), transform(b))`.
 
 
+`linspace(c1::ColorValue, c2::ColorValue, n=100)`
+
+Generates `n` colors in a linearly interpolated ramp from `c1` to
+`c2`, inclusive, returning an `Array` of colors
+
+`weighted_color_mean(w1::Real, c1::ColorValue, c2::ColorValue)`
+
+Returns a color that is the weighted mean of `c1` and `c2`, where `c1`
+has a weight 0 ≤ `w1` ≤ 1.
+
 # References
 
 What perceptually uniform colorspaces are and why you should be using them:

--- a/src/Color.jl
+++ b/src/Color.jl
@@ -1,6 +1,6 @@
 module Color
 
-import Base: convert, hex, isless, writemime
+import Base: convert, hex, isless, writemime, linspace
 import Base.Graphics: set_source, set_source_rgb, GraphicsContext
 
 export ColorValue, color,
@@ -927,6 +927,38 @@ distinguishable_colors(n::Integer; kwargs...) = distinguishable_colors(n, Array(
                                 ls::Vector{Float64},
                                 cs::Vector{Float64},
                                 hs::Vector{Float64})    distinguishable_colors(n, [seed], transform = transform, lchoices = ls, cchoices = cs, hchoices = hs)
+
+
+# Color ramp generation
+# ---------------------
+
+# weighted_color_mean(w1, c1, c2) gives a mean color "w1*c1 + (1-w1)*c2".
+for (T,a,b,c) in ((:RGB,:r,:g,:b), (:HSV,:h,:s,:v), (:HSL,:h,:s,:l),
+                  (:XYZ,:x,:y,:z), (:LAB,:l,:a,:b), (:LCHab,:l,:c,:h),
+                  (:LUV,:l,:u,:v), (:LCHuv,:l,:c,:h), (:LMS,:l,:m,:s))
+    @eval weighted_color_mean(w1::Real, c1::$T, c2::$T) =
+      let w2 = w1 >= 0 && w1 <= 1 ? 1 - w1 : throw(DomainError())
+          $T(c1.($(Expr(:quote, a))) * w1 + c2.($(Expr(:quote, a))) * w2, 
+             c1.($(Expr(:quote, b))) * w1 + c2.($(Expr(:quote, b))) * w2,
+             c1.($(Expr(:quote, c))) * w1 + c2.($(Expr(:quote, c))) * w2)
+      end
+end
+weighted_color_mean(w1::Real, c1::RGB24, c2::RGB24) =
+    convert(RGB24, weighted_color_mean(w1, convert(RGB, c1), convert(RGB, c2)))
+
+# return a linear ramp of n colors from c1 to c2, inclusive
+function linspace{T<:ColorValue}(c1::T, c2::T, n=100)
+    a = Array(T, int(n))
+    if n == 1
+        a[1] = c1
+        return a
+    end
+    n -= 1
+    for i = 0:n
+        a[i+1] = weighted_color_mean((n-i)/n, c1, c2)
+    end
+    a
+end
 
 
 # Displaying color swatches


### PR DESCRIPTION
The following are useful in generating gradient ramps:
- `linspace(c1::ColorValue, c2::ColorValue, n=100)` — Generates `n` colors in a linearly interpolated ramp from `c1` to `c2`, inclusive, returning an `Array` of colors
- `weighted_color_mean(w1::Real, c1::ColorValue, c2::ColorValue)` — Returns a color that is the weighted mean of `c1` and `c2`, where `c1` has a weight 0 ≤ `w1` ≤ 1.

Note that `weighted_color_mean` was already exported but does not seem to have been defined; I'm not sure if this is what you had in mind?

Technically, the above functions currently only work if `typeof(c1) == typeof(c2)`, but could easily be generalized if promotion rules for pairs of `ColorValue` types could be devised.
