### PR TITLE
Add RGBA to enable transparency in plots

### DIFF
--- a/test/construction.jl
+++ b/test/construction.jl
@@ -1,0 +1,6 @@
+using Color
+using Base.Test
+
+c = color("red")
+ac = RGBA(c)
+@test convert(Uint32, convert(RGBA32, ac)) == 0xffff0000

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,2 @@
+include("colordiff.jl")
+include("construction.jl")


### PR DESCRIPTION
I wanted to specify a filled region with a partially-transparent color; `RGBA(color("blue"), alpha)` seems to be a reasonable approach.
