### PR TITLE
Added support for the DIN99 UCS and color difference metric.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,17 @@ immutable LCHuv <: ColorValue
     h::Float64 # Hue
 ```
 
+### DIN99
+
+The DIN99 uniform colorspace as described in the DIN 6176 specification.
+
+```julia
+immutable DIN99 <: ColorValue
+    l::Float64 # L99 (Lightness)
+    a::Float64 # a99 (Red/Green)
+    b::Float64 # b99 (Blue/Yellow)
+```
+
 ### LMS
 
 Long-Medium-Short cone response values. Multiple methods of converting to LMS
@@ -186,6 +197,9 @@ Evaluate the
 difference formula. This gives an approximate measure of the perceptual
 difference between two colors to a typical viewer. A large number is returned
 for increasingly distinguishable colors.
+
+`colordiff_din99(a::ColorValue, b::ColorValue)`
+Evaluate the DIN99 color difference formula. This is a measure similar to the CIEDE2000 metric, but is computed in the DIN99 uniform color space. Larger numbers indicate a larger perceptual difference.
 
 ## Simulation of color blindness
 

--- a/test/din99.jl
+++ b/test/din99.jl
@@ -1,0 +1,43 @@
+
+using Color
+
+# Test data from the DIN 6176 specification
+const testdata = [
+((50,  10,  10), (61.43,   9.70,   3.76)),
+((50,  50,  50), (61.43,  28.64,  11.11)),
+((50, -10,  10), (61.43,  -5.57,   7.03)),
+((50, -50,  50), (61.43, -17.22,  21.75)),
+((50, -10, -10), (61.43,  -9.70,  -3.76)),
+((50, -50, -50), (61.43, -28.64, -11.11)),
+((50,  10, -10), (61.43,   5.57,  -7.03)),
+((50,  50, -50), (61.43,  17.22, -21.75)),
+(( 0,   0,   0), ( 0,      0,      0)),
+((100,  0,   0), (100,     0,      0))]
+                 
+# A high error threshold has been chosen because converting from DIN99
+# to CIELAB with only two decimal places of accuracy yields fairly inaccurate
+# results due to the exponentiation.
+const conveps = 0.05
+const diffeps = 0.01
+for (i, (a, b)) in enumerate(testdata)
+    converted = convert(DIN99, LAB(a...))
+    test = DIN99(b...)
+
+    @assert (abs(converted.l - test.l) < conveps)
+    @assert (abs(converted.a - test.a) < conveps)
+    @assert (abs(converted.b - test.b) < conveps)
+
+    converted = convert(LAB, DIN99(b...))
+    test = LAB(a...)
+
+    @assert (abs(converted.l - test.l) < conveps)
+    @assert (abs(converted.a - test.a) < conveps)
+    @assert (abs(converted.b - test.b) < conveps)
+
+    # This is not a real test of the color difference metric, but at least
+    # makes sure it isn't doing anything really crazy.
+    @assert (abs(colordiff_din99(convert(DIN99, LAB(a...)), DIN99(b...))) < diffeps)
+
+
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,3 @@
 include("colordiff.jl")
 include("construction.jl")
+include("din99.jl")


### PR DESCRIPTION
My first work in Julia and my first github pull request - bear with me!

I added in support for the DIN99 uniform color space. This space is used mostly in European industry, though it has some applications elsewhere. The intent of the space is to correct perceptual nonuniformities in CIELAB to allow for a euclidian difference metric.

Some simple test code is generated, though I will not have a dataset to confirm the metric (though I believe it is quite straightforward) for several weeks.
