### PR TITLE
Initial implementation of DIN99d

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ immutable DIN99 <: ColorValue
     b::Float64 # b99 (Blue/Yellow)
 ```
 
+### DIN99d
+
+The DIN99d uniform colorspace is an improvement on the DIN99 color space that adds a correction to the X tristimulus value in order to emulate the rotation term present in the DeltaE2000 equation.
+
+```julia
+immutable DIN99d <: ColorValue
+    l::Float64 # L99d (Lightness)
+    a::Float64 # a99d (Redish/Greenish)
+    b::Float64 # b99d (Blueish/Yellowish)
+```
+
 ### LMS
 
 Long-Medium-Short cone response values. Multiple methods of converting to LMS

--- a/src/Color.jl
+++ b/src/Color.jl
@@ -7,10 +7,11 @@ export ColorValue, color,
        ColourValue, colour,
        AlphaColorValue,
        weighted_color_mean, hex,
-       RGB, HSV, HSL, XYZ, LAB, LUV, LCHab, LCHuv, DIN99, LMS, RGB24,
-       RGBA, HSVA, HSLA, XYZA, LABA, LUVA, LCHabA, LCHuvA, DIN99A, LMSA, RGBA32,
+       RGB, HSV, HSL, XYZ, LAB, LUV, LCHab, LCHuv, DIN99, DIN99d, LMS, RGB24,
+       RGBA, HSVA, HSLA, XYZA, LABA, LUVA, LCHabA, LCHuvA, DIN99A, DIN99dA, LMSA, RGBA32,
        protanopic, deuteranopic, tritanopic,
-       cie_color_match, colordiff, colordiff_din99, distinguishable_colors,
+       cie_color_match, distinguishable_colors,
+       colordiff, colordiff_din99, colordiff_din99d,
        MSC, sequential_palette, diverging_palette, colormap
 
 # Delete once 0.2 is no longer supported:

--- a/src/colorspaces.jl
+++ b/src/colorspaces.jl
@@ -135,6 +135,7 @@ immutable LCHuv <: ColorValue
     LCHuv() = LCHuv(0, 0, 0)
 end
 
+
 # DIN99 (L99, a99, b99) - adaptation of CIELAB
 immutable DIN99 <: ColorValue
     l::Float64 # L99
@@ -146,6 +147,20 @@ immutable DIN99 <: ColorValue
     end
 
     DIN99() = DIN99(0, 0, 0)
+end
+
+
+# DIN99d (L99d, a99d, b99d) - Improvement on DIN99
+immutable DIN99d <: ColorValue
+    l::Float64 # L99d
+    a::Float64 # a99d
+    b::Float64 # b99d
+
+    function DIN99d(l::Number, a::Number, b::Number)
+        new(l, a, b)
+    end
+
+    DIN99d() = DIN99d(0, 0, 0)
 end
 
 
@@ -182,5 +197,6 @@ typealias LCHabA AlphaColorValue{LCHab}
 typealias LUVA AlphaColorValue{LUV}
 typealias LCHuvA AlphaColorValue{LCHuv}
 typealias DIN99A AlphaColorValue{DIN99}
+typealias DIN99dA AlphaColorValue{DIN99d}
 typealias LMSA AlphaColorValue{LMS}
 typealias RGBA32 AlphaColorValue{RGB24}

--- a/src/differences.jl
+++ b/src/differences.jl
@@ -89,3 +89,14 @@ function colordiff_din99(ai::ColorValue, bi::ColorValue)
     sqrt((a.l - b.l)^2 + (a.a - b.a)^2 + (a.b - b.b)^2)
 
 end
+
+
+# A color difference formula for the DIN99d uniform color space
+function colordiff_din99d(ai::ColorValue, bi::ColorValue)
+
+    a = convert(DIN99d, ai)
+    b = convert(DIN99d, bi)
+
+    sqrt((a.l - b.l)^2 + (a.a - b.a)^2 + (a.b - b.b)^2)
+
+end


### PR DESCRIPTION
DIN99d is a modified version of the DIN99 UCS. Based on experimental data, several coefficients were changed from the original standard, and a hue rotation is added in the XYZ tristimulus space to improve uniformity primarily in the blue regions of the space.

There are many different DIN99 standards; however, in my research, DIN99d seems to be one of the most supported and used. So, I thought that including it may be beneficial for some later on down the road.

My primary reason for including this space is that it is used to derive the Modified Uniform Oil Color Scale (mUOCS), which is being used for research at my institution. (http://www.sciencedirect.com/science/article/pii/S0260877412000957?np=y) If this is adding too much "clutter" to the library, I am happy to keep it as a personal addition.
