### PR TITLE
Hard-coded constants and updated commenting in DIN99*

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -260,9 +260,9 @@ function convert(::Type{XYZ}, c::DIN99d)
 
     l = (exp(c.l/325.22)-1)/0.0036
     # a = ee*cosd(50) - f/1.14*sind(50)
-    a = ee*0.6427876 - f/1.14*0.7660444
+    a = ee*0.6427876096865393 - f/1.14*0.766044443118978
     # b = ee*sind(50) - f/1.14*cosd(50)
-    b = ee*0.7660444 - f/1.14*0.6427876
+    b = ee*0.766044443118978 - f/1.14*0.6427876096865393
 
     adj = convert(XYZ, LAB(l, a, b))
 
@@ -341,9 +341,9 @@ function convert(::Type{LAB}, c::DIN99)
 
     # CIELAB a*b*
     # ciea = ee*cosd(16) - (f/0.7)*sind(16)
-    ciea = ee*0.9612617 - (f/0.7)*0.2756374
+    ciea = ee*0.9612616959383189 - (f/0.7)*0.27563735581699916
     # cieb = ee*sind(16) + (f/0.7)*cosd(16)
-    cieb = ee*0.2756374 + (f/0.7)*0.9612617
+    cieb = ee*0.27563735581699916 + (f/0.7)*0.9612616959383189
 
     # CIELAB L*
     ciel = (e^(c.l*ke/105.51)-1)/0.0158
@@ -379,9 +379,9 @@ function convert(::Type{LAB}, c::DIN99o)
 
     # CIELAB a*b* (revert b* axis compression)
     # ciea = eo*cosd(26) - (fo/0.83)*sind(26)
-    ciea = eo*0.8987940 - (fo/0.83)*0.4383711
+    ciea = eo*0.898794046299167 - (fo/0.83)*0.4383711467890774
     # cieb = eo*sind(26) + (fo/0.83)*cosd(26)
-    cieb = eo*0.4383711 + (fo/0.83)*0.8987940
+    cieb = eo*0.4383711467890774 + (fo/0.83)*0.898794046299167
 
     # CIELAB L* (revert logarithmic lightness compression)
     ciel = (e^(c.l*ke/303.67)-1)/0.0039
@@ -470,9 +470,9 @@ function convert(::Type{DIN99}, c::LAB)
 
     # Temporary value for redness and yellowness
     # ee = c.a*cosd(16) + c.b*sind(16)
-    ee = c.a*0.9612617 + c.b*0.2756374
+    ee = c.a*0.9612616959383189 + c.b*0.27563735581699916
     # f = -0.7*c.a*sind(16) + 0.7*c.b*cosd(16)
-    f = -0.7*c.a*0.2756374 + 0.7*c.b*0.9612617
+    f = -0.7*c.a*0.27563735581699916 + 0.7*c.b*0.9612616959383189
 
     # Temporary value for chroma
     g = sqrt(ee^2 + f^2)
@@ -521,9 +521,9 @@ function convert(::Type{DIN99d}, c::XYZ)
 
     # Calculate intermediate parameters
     # ee = lab.a*cosd(50) + lab.b*sind(50)
-    ee = lab.a*0.6427876 + lab.b*0.7660444
+    ee = lab.a*0.6427876096865393 + lab.b*0.766044443118978
     # f = 1.14*(lab.b*cosd(50) - lab.a*sind(50))
-    f = 1.14*(lab.b*0.6427876 - lab.a*0.7660444)
+    f = 1.14*(lab.b*0.6427876096865393 - lab.a*0.766044443118978)
     G = sqrt(ee^2+f^2)
 
     # Calculate hue/chroma
@@ -557,10 +557,10 @@ function convert(::Type{DIN99o}, c::LAB)
     # Temporary value for redness and yellowness
     # including rotation by 26°
     # eo = c.a*cosd(26) + c.b*sind(26)
-    eo = c.a*0.8987940 + c.b*0.4383711
+    eo = c.a*0.898794046299167 + c.b*0.4383711467890774
     # compression along the yellowness (blue-yellow) axis
     # fo = 0.83 * (c.b*cosd(26) - c.a*sind(26))
-    fo = 0.83 * (c.b*0.8987940 - c.a*0.4383711)
+    fo = 0.83 * (c.b*0.898794046299167 - c.a*0.4383711467890774)
 
     # Temporary value for chroma
     go = sqrt(eo^2 + fo^2)


### PR DESCRIPTION
Minor fixes to the conversion functions. I'm not positive if this will improve performance significantly or not with the Julia JIT, but it's generally good practice to hard-code constants anyhow. Also provided better commenting as to why `kch` and `ke` are set to 1; the standard provides for them, but does not recommend their use. If in the future someone really needs them, they are available.
