### PR TITLE
New CIE XYZ functions transformed from the CIE (2006) LMS functions

### DIFF
--- a/src/colormatch.jl
+++ b/src/colormatch.jl
@@ -1165,7 +1165,7 @@ const cie1931jv_cmf_table =
 #               testing of the effect of extrapolation down to 380 nm
 
 function colormatch(::Type{CIE2006_2_CMF}, wavelen::Real)
-    return interpolate_table(cie2006_2deg_xyz_cmf_table, 360.0, 1.0, wavelen)
+    return interpolate_table(cie2006_2deg_xyz_cmf_table, 380.0, 1.0, wavelen)
 end
 
 const cie2006_2deg_xyz_cmftable=
@@ -1579,7 +1579,7 @@ const cie2006_2deg_xyz_cmftable=
 
 
 function colormatch(::Type{CIE2006_10_CMF}, wavelen::Real)
-    return interpolate_table(cie2006_10deg_xyz_cmf_table, 360.0, 1.0, wavelen)
+    return interpolate_table(cie2006_10deg_xyz_cmf_table, 380.0, 1.0, wavelen)
 end
 
 const cie2006_10deg_xyz_cmf_table=


### PR DESCRIPTION
I added the new CIE2006 XYZ CMFs for 2° and 10° observers (proposed) transformed from the official CIE (2006) physiologically-relevant LMS fundamental colour matching functions. These LMS CMFs are based on the Stiles and Burch datasets. Details about the LMS to XYZ transformation can be found here:

http://www.cvrl.org/database/text/cienewxyz/cie2012xyz2.htm
http://www.cvrl.org/database/text/cienewxyz/cie2012xyz10.htm
