### PR TITLE
Make RGB(::Integer,::Integer,::Integer) make sense.

### DIFF
--- a/src/colorspaces.jl
+++ b/src/colorspaces.jl
@@ -32,7 +32,7 @@ immutable RGB{T<:Fractional} <: ColorValue{T}
 end
 RGB{T<:Fractional}(r::T, g::T, b::T) = RGB{T}(r, g, b)
 RGB(r, g, b) = (T = promote_type(typeof(r), typeof(g), typeof(b)); RGB{T}(r, g, b))
-RGB(r::Integer, g::Integer, b::Integer) = RGB{Float64}(r, g, b)
+RGB(r::Integer, g::Integer, b::Integer) = RGB(r/typemax(r), g/typemax(g), b/typemax(b))
 RGB() = RGB(0.0, 0.0, 0.0)
 
 typemin{T}(::Type{RGB{T}}) = RGB{T}(zero(T), zero(T), zero(T))


### PR DESCRIPTION
Is there anything I'm missing, or does 

```
RGB(r::Integer, g::Integer, b::Integer) = RGB{Float64}(r, g, b)
```

not make any sense because, according to the comments in `RGB`, the `r`, `g` and `b` values are within [0,1] and thus this line only permits to construct fully saturated colors?

This PR at least makes `RGB(0xa4,0x39,0x1f)` do what one'd expect, though the result of `RGB(164,57,31)` would still be unexpected. We could just always divide by `255` to make the latter one work, but that'd make handling 48 or 96 bit colors wrong. I'm in favor of 255 for the "least surprise."
