### PR TITLE
Delete isless for ColorValues

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -2,10 +2,6 @@
 include("cie_data.jl")
 
 
-# An arbitrary ordering for unique sorting.
-isless(a::RGB, b::RGB) = (a.r, a.g, a.b) < (b.r, b.g, b.b)
-isless(a::ColorValue, b::ColorValue) = convert(RGB, a) < convert(RGB, b)
-
 # Linear-interpolation in [a, b] where x is in [0,1],
 # or coerced to be if not.
 function lerp(x::Float64, a::Float64, b::Float64)


### PR DESCRIPTION
I have mixed feelings about this PR, but overall my concern is that defining an order on ColorValues is pretty arbitrary and leads to confusing behavior. For example:

```
julia> using Color

julia> c = RGB(1.2,0.8,0.4)
RGB{Float64}(1.2,0.8,0.4)

julia> o = RGB(1.0,1.0,1.0)
RGB{Float64}(1.0,1.0,1.0)

julia> min(c,o)
RGB{Float64}(1.0,1.0,1.0)
```

Naively I would have expected this to produce either an error or `RGB{Float}(1.0,0.8,0.4)`, just like

```
julia> a = [1.2,0.8,0.4];

julia> b = [1.0,1.0,1.0];

julia> min(a,b)
3-element Array{Float64,1}:
 1.0
 0.8
 0.4
```

With this PR, `min(cv1, cv2)` will yield an error. If others feel that the elementwise result is more natural, I'll add another commit to this PR. 

Note that we don't have to delete `isless` to get this `min` behavior, of course; it's only that `min` calls `isless` in the absence of a more specialized method. I'm proposing that we delete `isless` out of concern that it's simply too poorly-defined. If the only purpose for defining `isless` was to allow one to sort colorvalues, then there is a more restricted way to solve that problem: `sort(A, lt=comparisonfunc)`.
