### PR TITLE
Fixes conversion to/from Ufixed* types

### DIFF
--- a/src/colorspaces.jl
+++ b/src/colorspaces.jl
@@ -293,3 +293,5 @@ argb32{T}(c::ColorValue{T}) = ARGB32(convert(RGB24,c).color | 0xff000000)
 
 const CVconcrete = (HSV, HSL, XYZ, xyY, Lab, Luv, LCHab, LCHuv, DIN99, DIN99d, DIN99o, LMS)
 const CVparametric = tuple(RGB, CVconcrete...)
+const CVfractional = (RGB, XYZ)
+const CVfloatingpoint = (HSV, HSL, xyY, Lab, Luv, LCHab, LCHuv, DIN99, DIN99d, DIN99o, LMS)

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -36,6 +36,36 @@ for Cto in Color.CVparametric
     @test typeof(convert(Cto{Float32}, red24)) == Cto{Float32}
 end
 
+# Test conversion from Ufixed types
+for Cto in Color.CVfloatingpoint
+    for Cfrom in Color.CVfractional
+        for Tto in (Float32, Float64)
+            for Tfrom in (Ufixed8, Ufixed10, Ufixed12, Ufixed14, Ufixed16)
+                c = convert(Cfrom{Tfrom}, red)
+                @test typeof(c) == Cfrom{Tfrom}
+                c1 = convert(Cto, c)
+                @test eltype(c1) == Float64
+                c2 = convert(Cto{Tto}, c)
+                @test typeof(c2) == Cto{Tto}
+            end
+        end
+    end
+end
+
+# Test conversion to Ufixed types
+for Cto in Color.CVfractional
+    for Cfrom in Color.CVfloatingpoint
+        for Tto in (Ufixed8, Ufixed10, Ufixed12, Ufixed14, Ufixed16)
+            for Tfrom in (Float32, Float64)
+                c = convert(Cfrom{Tfrom}, red)
+                @test typeof(c) == Cfrom{Tfrom}
+                c2 = convert(Cto{Tto}, c)
+                @test typeof(c2) == Cto{Tto}
+            end
+        end
+    end
+end
+
 ac = rgba(red)
 @test convert(ARGB32, ac) == ARGB32(0xffff0000)
 @test convert(Uint32, convert(ARGB32, ac)) == 0xffff0000


### PR DESCRIPTION
- Previously, conversions were attempting to force conversion to, e.g., Lab{Ufixed8}, which is not a valid type.
- Conversions from `ColorValue{Ufixed}` types to abstract `ColorValue`s (i.e., without a specified type parameter) failed (these conversions are allowed from `ColorValue{FloatingPoint}` types)
- Some conversions from `ColorValue{Ufixed}` to `ColorValue{FloatingPoint}` did not round trip well (e.g., `RGB{Ufixed8}` -> `Lab{Float64}` -> `RGB{Ufixed8}`)
- Added tests.

Previously:

``` julia
julia> img[1]
RGB{Ufixed8}(0.035,0.106,0.208)

julia> convert(Lab{Float64}, img[1])
Lab{Float64}(9.789275714438482,3.524345941228191,-19.242882752985235)

julia> convert(RGB{Ufixed8}, Lab{Float64}(9.789275714438482,3.524345941228191,-19.242882752985235))
RGB{Ufixed8}(0.031,0.114,0.208)

julia> # ^^^^^^^^^^^^^^^^^^^^ Inexact conversion on previous line

julia> convert(Lab, img[1])
ERROR: type: Lab: in T, expected T<:FloatingPoint, got Type{UfixedBase{Uint8,8}}
 in convert at /home/kevin/.julia/v0.4/Color/src/conversions.jl:27
```

With this PR:

``` julia
julia> convert(Lab, img[1])
Lab{Float64}(9.789275714438482,3.524345941228191,-19.242882752985235)

julia> convert(RGB{Ufixed8}, ans)
RGB{Ufixed8}(0.035,0.106,0.208)
```

While the behavior is obviously better, this may not be the right fix, so I would appreciate feedback.

Cc: @timholy 
