### PR TITLE
Precise compatibility versioning, via Compat

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.3-
+Compat
 FixedPointNumbers

--- a/src/Color.jl
+++ b/src/Color.jl
@@ -1,6 +1,6 @@
 module Color
 
-using FixedPointNumbers
+using FixedPointNumbers, Compat
 
 typealias Fractional Union(FloatingPoint, FixedPoint)
 
@@ -25,18 +25,6 @@ if !isdefined(:rad2deg)
   const rad2deg = radians2degrees
   const deg2rad = degrees2radians
 end
-
-# Dict compatibility
-if VERSION < v"0.4-"
-    macro Dict(pairs...)
-        Expr(:dict, pairs...)
-    end
-else
-    macro Dict(pairs...)
-        Expr(:call, :Dict, pairs...)
-    end
-end
-
 
 # The core; every other include will need these type definitions
 include("colorspaces.jl")

--- a/src/maps_data.jl
+++ b/src/maps_data.jl
@@ -3,7 +3,7 @@
 
 # Colormap parameters
 
-const colormaps_sequential = @Dict(
+const colormaps_sequential = Compat.@Dict(
     #single hue
     #name        hue   w     d     c     s     b     wcolor      dcolor
     "blues"   => (255, 0.3,  0.25, 0.88, 0.6,  0.75, RGB(1,1,0), RGB(0,0,1)),
@@ -14,7 +14,7 @@ const colormaps_sequential = @Dict(
     "reds"    => (12,  0.15, 0.25, 0.8,  0.85, 0.6,  RGB(1,1,0), RGB(0.3,0.1,0.1))
 )
 
-const colormaps_diverging = @Dict(
+const colormaps_diverging = Compat.@Dict(
     #name         h1   h2    w     d1    d2    c      s     b      wcolor      dcolor      dcolor2
     "rdbu"    => (12,  255,  0.2,  0.6,  0.0,  0.85,  0.6,  0.65,  RGB(1,1,0), RGB(1,0,0), RGB(0,0,1))
 )

--- a/src/names_data.jl
+++ b/src/names_data.jl
@@ -2,7 +2,7 @@
 # This is the union of every color defined in X11 and in SVG, prefering the SVG
 # definition when they clash.
 
-const color_names = @Dict(
+const color_names = Compat.@Dict(
     "aliceblue"            => (240, 248, 255),
     "antiquewhite"         => (250, 235, 215),
     "antiquewhite1"        => (255, 239, 219),
@@ -665,4 +665,3 @@ const color_names = @Dict(
     "yellow4"              => (139, 139,   0),
     "yellowgreen"          => (154, 205,  50)
 )
-


### PR DESCRIPTION
Went to check the commit to update METADATA, noticed versioning wasn't precise, figured might as well switch to Compat at the same time.
