### PR TITLE
Attempt to run Julia (nightly) again for coverage numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,5 @@ notifications:
     email: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - if [[ $TRAVIS_JULIA_VERSION = "nightly" ]]; then
-         julia -e 'Pkg.clone(pwd()); Pkg.build("Color"); Pkg.test("Color"; coverage=true)';
-         julia -e 'cd(Pkg.dir("Color")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
-      fi
+    - julia -e 'Pkg.clone(pwd()); Pkg.build("Color"); Pkg.test("Color"; coverage=true)';
+    - julia -e 'cd(Pkg.dir("Color")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: julia
 os:
+    - osx
     - linux
 julia:
     - release
     - nightly
 notifications:
     email: false
-after_success:
-    - julia -e 'cd(Pkg.dir("Color")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+script:
+    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    - if [[ $TRAVIS_JULIA_VERSION = "nightly" ]]; then
+         julia -e 'Pkg.clone(pwd()); Pkg.build("Color"); Pkg.test("Color"; coverage=true)';
+         julia -e 'cd(Pkg.dir("Color")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+      fi


### PR DESCRIPTION
This PR attempts to close #79 by rerunning Julia nightlies to generate coverage data.

It all seems to work, except that Coverage fails with an inscrutable error:

```
Coverage.MallocInfo[]
src/algorithms.jl
src/cie_data.jl
src/Color.jl
src/colormaps.jl
src/colormatch.jl
src/colorspaces.jl
src/conversions.jl
src/differences.jl
src/display.jl
src/maps_data.jl
src/names_data.jl
src/parse.jl
src/utilities.jl
ERROR: cfunction: return type of write does not match
 in associate_stream at /home/travis/.julia/v0.4/GnuTLS/src/GnuTLS.jl:299
 in open_stream at /home/travis/.julia/v0.4/Requests/src/Requests.jl:219
 in send_multipart at /home/travis/.julia/v0.4/Requests/src/Requests.jl:515
 in do_request at /home/travis/.julia/v0.4/Requests/src/Requests.jl:562
 in post at /home/travis/.julia/v0.4/Requests/src/Requests.jl:579
 in submit at /home/travis/.julia/v0.4/Coverage/src/Coverage.jl:217
 in process_options at ./client.jl:241
 in _start at ./client.jl:403
```

I'm not sure what could have changed in the past 4 days between [build #116](https://travis-ci.org/JuliaLang/Color.jl/builds/51186285) and [build #115](https://travis-ci.org/JuliaLang/Color.jl/builds/50709689) to cause this. And then there's [build #118](https://travis-ci.org/JuliaLang/Color.jl/jobs/51187796#L8500) where printing out the environment apparently circumvents this error. Any ideas @IainNZ ?