### PR TITLE
AbstractVector changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,17 +353,17 @@ Generate `n` maximally distinguishable colors in LCHab space.
 
 ```julia
 distinguishable_colors(n::Integer,seed::ColorValue)
-distinguishable_colors{T<:ColorValue}(n::Integer,seed::Vector{T})
+distinguishable_colors{T<:ColorValue}(n::Integer,seed::AbstractVector{T})
 ```
 
 A seed color or array of seed colors may be provided to `distinguishable_colors`, and the remaining colors will be chosen to be maximally distinguishable from the seed colors and each other.
 
 ```julia
-distinguishable_colors{T<:ColorValue}(n::Integer, seed::Vector{T};
+distinguishable_colors{T<:ColorValue}(n::Integer, seed::AbstractVector{T};
     transform::Function = identity,
-    lchoices::Vector{Float64} = linspace(0, 100, 15),
-    cchoices::Vector{Float64} = linspace(0, 100, 15),
-    hchoices::Vector{Float64} = linspace(0, 340, 20)
+    lchoices::AbstractVector = linspace(0, 100, 15),
+    cchoices::AbstractVector = linspace(0, 100, 15),
+    hchoices::AbstractVector = linspace(0, 340, 20)
 )
 ```
 

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -24,11 +24,11 @@ include("maps_data.jl")
 #   A Vector{ColorValue} of length n.
 #
 function distinguishable_colors{T<:ColorValue}(n::Integer,
-                            seed::Vector{T};
+                            seed::AbstractVector{T};
                             transform::Function = identity,
-                            lchoices::Vector = linspace(0, 100, 15),
-                            cchoices::Vector = linspace(0, 100, 15),
-                            hchoices::Vector = linspace(0, 340, 20))
+                            lchoices::AbstractVector = linspace(0, 100, 15),
+                            cchoices::AbstractVector = linspace(0, 100, 15),
+                            hchoices::AbstractVector = linspace(0, 340, 20))
     if n <= length(seed)
         return seed[1:n]
     end


### PR DESCRIPTION
Required now that linspace returns an iterable thing, not an actual vector. The type restriction could probably even be removed completely, or reduced to whatever the type for an iterable thing is.