### PR TITLE
Adding a show method for FloatingPoint color types

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -9,6 +9,12 @@ function makeshow(CV, CVstr, fields)
             $ex
         end
     end)
+    eval(quote
+        function show{T<:FloatingPoint}(io::IO, c::$CV{T})
+            print(io, "$($CVstr){", T, "}(")
+            $ex
+        end
+    end)
 end
 
 for (CV, CVstr, fields) in ((RGB,  "RGB",  (:(c.r),:(c.g),:(c.b))),


### PR DESCRIPTION
For RGB,XYZ,RGBA{FloatingPoint} types, the show function will now print the
values in a more compact form. This was motivated by the fact that
ImageView.jl's way of showing the color value in the window caused overflowing
text without this change.
