### PR TITLE
add __precompile__() to header

### DIFF
--- a/src/Color.jl
+++ b/src/Color.jl
@@ -1,3 +1,5 @@
+VERSION >= v"0.4.0-dev+6521" && __precompile__()
+
 module Color
 
 using FixedPointNumbers, Compat


### PR DESCRIPTION
... since this module is safe to precompile (and large).  See also JeffBezanson/FixedPointNumbers.jl#24