### PR TITLE
Make Color uninstallable on julia 0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.3 0.4
 Compat 0.2
-FixedPointNumbers
+FixedPointNumbers 0.0.0 0.0.10
 Graphics 0.1


### PR DESCRIPTION
It's deprecated in favor of Colors.