### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
     - osx
     - linux
 julia:
-    - release
+    - 0.3
     - nightly
 notifications:
     email: false


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this
package supports julia 0.3 so it should continue to be tested